### PR TITLE
mlocate package deprecated in favor of plocate #17

### DIFF
--- a/docs/11.md
+++ b/docs/11.md
@@ -34,7 +34,7 @@ If you're looking for a file called `access.log` then the quickest approach is t
 	/var/log/apache2/access.log.1
 	/var/log/apache2/access.log.2.gz
 
-(If `locate` is not installed, do so with `sudo apt install mlocate`)
+(If `locate` is not installed, do so with `sudo apt install plocate`)
 
 As you can see, by default it treats a search for _"something"_ as a search for _"\*something\*"_. It’s very fast because it searches an index, but if this index is out of date or missing it may not give you the answer you’re looking for.  This is because the index is created by the `updatedb` command - typically run only nightly by `cron`.  It may therefore be out of date for recently added files, so it can be worthwhile updating the index by manually running: `sudo updatedb`.
 


### PR DESCRIPTION
mlocate package deprecated in favor of plocate.

Fixes #17 