### PR TITLE
Update Day 15 APT sources example

### DIFF
--- a/docs/15.md
+++ b/docs/15.md
@@ -33,9 +33,12 @@ The version number is particularly important because it controls the versions of
 
 We'll be discussing the "package manager" used by the Debian and Ubuntu distributions, and dozens of derivatives. This uses the `apt` command, but for most purposes the competing `yum` and `dnf` commands used by Fedora, RHEL, CentOS and Scientific Linux work in a very similar way - as do the equivalent utilities in  other versions.
 
-The configuration is done with files under the _/etc/apt_ directory, and to see where the packages you install are coming from, use `less` to view _/etc/apt/sources.list_ where you'll see lines that are clearly specifying URLs to a “repository” for your specific version:
+The configuration is done with files under the _/etc/apt_ directory, and to see where the packages you install are coming from, use `less` to view _/etc/apt/sources.list.d/ubuntu.sources_ where you'll see entries that specify repository URIs and suites for your specific version:
 
-     deb http://archive.ubuntu.com/ubuntu precise-security main restricted universe
+     Types: deb
+     URIs: http://archive.ubuntu.com/ubuntu/
+     Suites: noble noble-updates noble-backports
+     Components: main restricted universe multiverse
 
 There's no need to be concerned with the exact syntax of this for now, but what’s fairly common is to want to add extra repositories - and this is what we'll deal with next.
 

--- a/docs/15.md
+++ b/docs/15.md
@@ -33,7 +33,7 @@ The version number is particularly important because it controls the versions of
 
 We'll be discussing the "package manager" used by the Debian and Ubuntu distributions, and dozens of derivatives. This uses the `apt` command, but for most purposes the competing `yum` and `dnf` commands used by Fedora, RHEL, CentOS and Scientific Linux work in a very similar way - as do the equivalent utilities in  other versions.
 
-The configuration is done with files under the _/etc/apt_ directory, and to see where the packages you install are coming from, use `less` to view _/etc/apt/sources.list.d/ubuntu.sources_ where you'll see entries that specify repository URIs and suites for your specific version:
+The configuration is done with files under the _/etc/apt_ directory, and to see where the packages you install are coming from, use `less` to view _/etc/apt/sources.list.d/ubuntu.sources_ where you'll see entries that specify repository URIs, suites, and components for your specific version:
 
      Types: deb
      URIs: http://archive.ubuntu.com/ubuntu/


### PR DESCRIPTION
Hi, thank you for maintaining this course.

This PR updates the Day 15 APT sources example to match the current Ubuntu 24.04+ behavior and the existing Day 4 wording.

Day 15 still referred to:

```bash
/etc/apt/sources.list
```

and showed the older one-line source format:

```text
deb http://archive.ubuntu.com/ubuntu precise-security main restricted universe
```

This PR updates that section to point learners to:

```bash
/etc/apt/sources.list.d/ubuntu.sources
```

and uses a Deb822-style example:

```text
Types: deb
URIs: http://archive.ubuntu.com/ubuntu/
Suites: noble noble-updates noble-backports
Components: main restricted universe multiverse
```

This keeps the section focused on the same concept while bringing the example in line with current Ubuntu releases.

Related to #20.