### PR TITLE
Closes #22 - updated tldr installation instructions 

### DIFF
--- a/docs/02.md
+++ b/docs/02.md
@@ -30,19 +30,29 @@ Which leads us to the famous acronym [RTFM](https://en.wikipedia.org/wiki/RTFM).
 
 Starting with the `man` command. Each application installed comes with its own page in this manual, so that you can look at the page for `pwd` to see the full detail on the syntax like this:
 
-`man pwd`
+```bash
+man pwd
+```
 
 You might also try:
 
-     man cp
-     man mv
-     man grep
-     man ls
-     man man
+```bash
+man cp
+man mv
+man grep
+man ls
+man man
+```
+
+> **Note about Ubuntu Minimized - if you're using a [Local Server/VM](00-Local-Server.md):**
+> because this is a reduced/stripped-down version of Ubuntu Server, unfortunately the `man-db`
+> package will not be installed by default, and you won't have the manual pages available. To
+> fix this without unminimizing it, just install the required packages with
+> `sudo apt install man-db manpages manpages-dev`
 
 As you’ll see, these are excellent for the detailed syntax of a command, but many are extremely terse, and for others the amount of detail can be somewhat daunting!
 
-And that's why `tldr` is such a powerful tool! You can easily [install it](https://tldr.sh/) with `sudo apt install tldr` or follow [this demo](https://asciinema.org/a/619672).
+And that's why `tldr` is such a powerful tool! You can install it with `snap install tldr` or follow [their wiki](https://github.com/tldr-pages/tldr/wiki/Clients#official-console-clients) for more options.
 
 ```bash
 $ tldr pwd
@@ -72,7 +82,7 @@ pwdx (1)             - report current working directory of a process
 
 But you'll soon find out that not every command has a manual that you can read with `man`. Those commands are contained within the shell itself and we call them [builtin commands](https://www.gnu.org/software/bash/manual/html_node/Shell-Builtin-Commands.html).
 
-There are some overlaping (i.e. builtin commands that also have a man page) but if `man` does not work, we use `help` to display information about them.
+There are some overlapping (i.e. builtin commands that also have a man page) but if `man` does not work, we use `help` to display information about them.
 
 ```bash
 $ man export


### PR DESCRIPTION
Since [tldr](https://tldr.sh/) official console clients are no longer supported through `apt`, I'm replacing the current instructions with the `snap` option, for simplicity sake. Going with `pipx` might be too much for a Day 2, and `snap` is a default with Ubuntu. Probably worth revisiting in Day 15 when mentioning other packaging methods.

Also added a note about `man-db` missing in ubuntu minimized, and how to restore it.